### PR TITLE
feat(webhook): add webhook type extraction and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,44 @@ curl -X POST http://localhost:3000/webhook/stripe/payments \
 
 The path can be anything you want (e.g., `/webhook/paypal`, `/webhook/github/push`).
 
+## Webhook Type Detection
+
+The app automatically detects webhook types from common providers by inspecting:
+
+**Body fields** (checked in order):
+- `type` - Used by Stripe, Clerk, and others
+- `event` - Common generic field
+- `event_type` - Alternative naming convention
+- `action` - Used by GitHub for some events
+- `kind` - Alternative naming convention
+
+**Headers** (checked if body fields not found):
+- `X-GitHub-Event` - GitHub webhooks
+- `X-Shopify-Topic` - Shopify webhooks
+- `X-Event-Type` - Generic event type header
+- `X-Event-Name` - Alternative event name header
+
+If no type is detected, webhooks are marked as `unknown`.
+
+### Filtering by Type
+
+The dashboard includes a type filter dropdown that shows all detected webhook types. You can:
+- Filter webhooks by type to see only specific events
+- Combine type filtering with path and method filters
+- View the webhook type in the dashboard table
+
+### API Endpoints
+
+Get unique webhook types:
+```bash
+curl http://localhost:3000/api/webhook-types
+```
+
+Filter webhooks by type:
+```bash
+curl http://localhost:3000/api/webhooks?webhook_type=payment.success
+```
+
 ## Deploy to Heroku
 
 ```bash

--- a/client/src/components/WebhookTable.jsx
+++ b/client/src/components/WebhookTable.jsx
@@ -45,6 +45,7 @@ function WebhookTable({ webhooks, loading, onSelect, onDelete, pagination, onPag
             <tr>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Time</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Method</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Path</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Body Preview</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
@@ -63,6 +64,11 @@ function WebhookTable({ webhooks, loading, onSelect, onDelete, pagination, onPag
                 <td className="px-4 py-3">
                   <span className={`px-2 py-1 text-xs font-medium rounded ${getMethodColor(webhook.method)}`}>
                     {webhook.method}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <span className="px-2 py-1 bg-blue-900 text-white rounded text-xs font-medium">
+                    {webhook.webhook_type || 'unknown'}
                   </span>
                 </td>
                 <td className="px-4 py-3 text-sm font-mono text-gray-900">

--- a/server/db.js
+++ b/server/db.js
@@ -30,10 +30,6 @@ async function initializeDatabase() {
       CREATE INDEX IF NOT EXISTS idx_webhooks_path ON webhooks(path)
     `);
 
-    await client.query(`
-      CREATE INDEX IF NOT EXISTS idx_webhooks_type ON webhooks(webhook_type)
-    `);
-
     // Add webhook_type column if it doesn't exist (for existing databases)
     await client.query(`
       DO $$
@@ -43,9 +39,13 @@ async function initializeDatabase() {
           WHERE table_name = 'webhooks' AND column_name = 'webhook_type'
         ) THEN
           ALTER TABLE webhooks ADD COLUMN webhook_type VARCHAR(255);
-          CREATE INDEX idx_webhooks_type ON webhooks(webhook_type);
         END IF;
       END $$;
+    `);
+
+    // Create webhook_type index (after ensuring column exists)
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_webhooks_type ON webhooks(webhook_type)
     `);
 
     console.log('Database initialized successfully');

--- a/server/db.js
+++ b/server/db.js
@@ -118,7 +118,8 @@ async function deleteWebhook(id) {
 
 async function deleteOldWebhooks(days = 90) {
   const result = await pool.query(
-    `DELETE FROM webhooks WHERE created_at < NOW() - INTERVAL '${days} days' RETURNING id`
+    `DELETE FROM webhooks WHERE created_at < NOW() - INTERVAL $1 RETURNING id`,
+    [`${days} days`]
   );
   return result.rowCount;
 }

--- a/server/db.js
+++ b/server/db.js
@@ -17,6 +17,7 @@ async function initializeDatabase() {
         body JSONB,
         query_params JSONB,
         source_ip VARCHAR(45),
+        webhook_type VARCHAR(255),
         created_at TIMESTAMP DEFAULT NOW()
       )
     `);
@@ -29,46 +30,76 @@ async function initializeDatabase() {
       CREATE INDEX IF NOT EXISTS idx_webhooks_path ON webhooks(path)
     `);
 
+    await client.query(`
+      CREATE INDEX IF NOT EXISTS idx_webhooks_type ON webhooks(webhook_type)
+    `);
+
+    // Add webhook_type column if it doesn't exist (for existing databases)
+    await client.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM information_schema.columns
+          WHERE table_name = 'webhooks' AND column_name = 'webhook_type'
+        ) THEN
+          ALTER TABLE webhooks ADD COLUMN webhook_type VARCHAR(255);
+          CREATE INDEX idx_webhooks_type ON webhooks(webhook_type);
+        END IF;
+      END $$;
+    `);
+
     console.log('Database initialized successfully');
   } finally {
     client.release();
   }
 }
 
-async function insertWebhook({ path, method, headers, body, queryParams, sourceIp }) {
+async function insertWebhook({ path, method, headers, body, queryParams, sourceIp, webhookType }) {
   const result = await pool.query(
-    `INSERT INTO webhooks (path, method, headers, body, query_params, source_ip)
-     VALUES ($1, $2, $3, $4, $5, $6)
+    `INSERT INTO webhooks (path, method, headers, body, query_params, source_ip, webhook_type)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
      RETURNING *`,
-    [path, method, JSON.stringify(headers), JSON.stringify(body), JSON.stringify(queryParams), sourceIp]
+    [path, method, JSON.stringify(headers), JSON.stringify(body), JSON.stringify(queryParams), sourceIp, webhookType]
   );
   return result.rows[0];
 }
 
-async function getWebhooks({ limit = 50, offset = 0, path = null }) {
-  let query = 'SELECT * FROM webhooks';
+async function getWebhooks({ limit = 50, offset = 0, path = null, webhookType = null }) {
+  let query = 'SELECT * FROM webhooks WHERE 1=1';
   const params = [];
+  let paramCount = 0;
 
   if (path) {
-    query += ' WHERE path LIKE $1';
     params.push(`%${path}%`);
+    query += ` AND path LIKE $${++paramCount}`;
+  }
+
+  if (webhookType) {
+    params.push(webhookType);
+    query += ` AND webhook_type = $${++paramCount}`;
   }
 
   query += ' ORDER BY created_at DESC';
-  query += ` LIMIT $${params.length + 1} OFFSET $${params.length + 2}`;
+  query += ` LIMIT $${++paramCount} OFFSET $${++paramCount}`;
   params.push(limit, offset);
 
   const result = await pool.query(query, params);
   return result.rows;
 }
 
-async function getWebhookCount(path = null) {
-  let query = 'SELECT COUNT(*) FROM webhooks';
+async function getWebhookCount(path = null, webhookType = null) {
+  let query = 'SELECT COUNT(*) FROM webhooks WHERE 1=1';
   const params = [];
+  let paramCount = 0;
 
   if (path) {
-    query += ' WHERE path LIKE $1';
     params.push(`%${path}%`);
+    query += ` AND path LIKE $${++paramCount}`;
+  }
+
+  if (webhookType) {
+    params.push(webhookType);
+    query += ` AND webhook_type = $${++paramCount}`;
   }
 
   const result = await pool.query(query, params);
@@ -92,6 +123,13 @@ async function deleteOldWebhooks(days = 90) {
   return result.rowCount;
 }
 
+async function getUniqueWebhookTypes() {
+  const result = await pool.query(
+    'SELECT DISTINCT webhook_type FROM webhooks WHERE webhook_type IS NOT NULL ORDER BY webhook_type'
+  );
+  return result.rows.map(row => row.webhook_type);
+}
+
 module.exports = {
   pool,
   initializeDatabase,
@@ -100,5 +138,6 @@ module.exports = {
   getWebhookCount,
   getWebhookById,
   deleteWebhook,
-  deleteOldWebhooks
+  deleteOldWebhooks,
+  getUniqueWebhookTypes
 };

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -1,5 +1,5 @@
 const express = require('express');
-const { getWebhooks, getWebhookCount, getWebhookById, deleteWebhook } = require('../db');
+const { getWebhooks, getWebhookCount, getWebhookById, deleteWebhook, getUniqueWebhookTypes } = require('../db');
 
 const router = express.Router();
 
@@ -10,10 +10,11 @@ router.get('/webhooks', async (req, res) => {
     const page = parseInt(req.query.page, 10) || 1;
     const offset = (page - 1) * limit;
     const path = req.query.path || null;
+    const webhookType = req.query.webhook_type || null;
 
     const [webhooks, total] = await Promise.all([
-      getWebhooks({ limit, offset, path }),
-      getWebhookCount(path)
+      getWebhooks({ limit, offset, path, webhookType }),
+      getWebhookCount(path, webhookType)
     ]);
 
     res.json({
@@ -60,6 +61,17 @@ router.delete('/webhooks/:id', async (req, res) => {
   } catch (error) {
     console.error('Error deleting webhook:', error);
     res.status(500).json({ error: 'Failed to delete webhook' });
+  }
+});
+
+// Get unique webhook types
+router.get('/webhook-types', async (req, res) => {
+  try {
+    const types = await getUniqueWebhookTypes();
+    res.json(types);
+  } catch (error) {
+    console.error('Error fetching webhook types:', error);
+    res.status(500).json({ error: 'Failed to fetch webhook types' });
   }
 });
 

--- a/server/routes/webhook.js
+++ b/server/routes/webhook.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { insertWebhook } = require('../db');
+const { extractWebhookType } = require('../utils/extractWebhookType');
 
 const router = express.Router();
 
@@ -8,6 +9,9 @@ router.all('/*', async (req, res) => {
   try {
     // Extract the path after /webhook/
     const webhookPath = req.params[0] || 'default';
+
+    // Extract webhook type from body or headers
+    const webhookType = extractWebhookType(req.body, req.headers);
 
     // Get client IP (handle proxies like Heroku)
     const sourceIp = req.headers['x-forwarded-for']?.split(',')[0]?.trim() ||
@@ -21,16 +25,18 @@ router.all('/*', async (req, res) => {
       headers: req.headers,
       body: req.body,
       queryParams: req.query,
-      sourceIp
+      sourceIp,
+      webhookType
     });
 
-    console.log(`Webhook received: ${req.method} /webhook/${webhookPath}`);
+    console.log(`Webhook received: ${req.method} /webhook/${webhookPath} [${webhookType}]`);
 
     res.status(200).json({
       success: true,
       message: 'Webhook received',
       id: webhook.id,
       path: webhookPath,
+      type: webhookType,
       timestamp: webhook.created_at
     });
   } catch (error) {

--- a/server/utils/extractWebhookType.js
+++ b/server/utils/extractWebhookType.js
@@ -1,0 +1,42 @@
+/**
+ * Extract webhook type from body or headers
+ * Checks common locations used by popular webhook providers
+ */
+function extractWebhookType(body, headers) {
+  // Normalize body (might be string, object, or null)
+  const parsedBody = typeof body === 'string'
+    ? tryParseJSON(body)
+    : body;
+
+  // Try common body fields (priority order)
+  if (parsedBody?.type) return String(parsedBody.type);
+  if (parsedBody?.event) return String(parsedBody.event);
+  if (parsedBody?.event_type) return String(parsedBody.event_type);
+  if (parsedBody?.action) return String(parsedBody.action);
+  if (parsedBody?.kind) return String(parsedBody.kind);
+
+  // Normalize headers (case-insensitive)
+  const lowerHeaders = Object.keys(headers || {}).reduce((acc, key) => {
+    acc[key.toLowerCase()] = headers[key];
+    return acc;
+  }, {});
+
+  // Try common headers
+  if (lowerHeaders['x-github-event']) return String(lowerHeaders['x-github-event']);
+  if (lowerHeaders['x-shopify-topic']) return String(lowerHeaders['x-shopify-topic']);
+  if (lowerHeaders['x-event-type']) return String(lowerHeaders['x-event-type']);
+  if (lowerHeaders['x-event-name']) return String(lowerHeaders['x-event-name']);
+
+  // Default
+  return 'unknown';
+}
+
+function tryParseJSON(str) {
+  try {
+    return JSON.parse(str);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { extractWebhookType };


### PR DESCRIPTION
Closes #10

Implements webhook type extraction and filtering as specified in the issue.

## Changes

- Add webhook type extraction utility that checks common body fields and headers
- Update database schema to add webhook_type column with indexes
- Add API endpoint for fetching unique webhook types
- Update webhooks API to support filtering by type
- Add Type column to UI table with visual styling
- Add Type filter dropdown in dashboard
- Log webhook type on receipt

Supports Stripe, GitHub, Shopify, and generic webhook providers.

Generated with [Claude Code](https://claude.ai/code)